### PR TITLE
2 kitchen verify

### DIFF
--- a/lib/kitchen/driver/xenserver.rb
+++ b/lib/kitchen/driver/xenserver.rb
@@ -38,6 +38,7 @@ module Kitchen
       default_config :username, 'root'
       default_config :password, 'VM_PASSWORD'
       default_config :ip_address, 'VM_STATIC_IP'
+      default_config :hostname, 'VM_STATIC_HOSTNAME / IP' #This variable is used by 'kitchen verify' for SSH.
       default_config :port, '22'
       default_config :ssh_timeout, 3
       default_config :ssh_retries, 50
@@ -123,12 +124,12 @@ module Kitchen
         end
       end
 
-      def verify(state)
-        Kitchen::SSH.new(config[:ip_address], config[:username], password: config[:password]) do |conn|
-          run_remote(busser.sync_cmd, conn)
-          run_remote(busser.run_cmd, conn)
-        end
-      end
+#      def verify(state)
+#        Kitchen::SSH.new(config[:ip_address], config[:username], password: config[:password]) do |conn|
+#          run_remote(busser.sync_cmd, conn)
+#          run_remote(busser.run_cmd, conn)
+#        end
+#      end
 
     end
   end

--- a/lib/kitchen/driver/xenserver.rb
+++ b/lib/kitchen/driver/xenserver.rb
@@ -123,14 +123,6 @@ module Kitchen
           info("Server #{config[:server_name]} has been shut down cleanly.")
         end
       end
-
-#      def verify(state)
-#        Kitchen::SSH.new(config[:ip_address], config[:username], password: config[:password]) do |conn|
-#          run_remote(busser.sync_cmd, conn)
-#          run_remote(busser.run_cmd, conn)
-#        end
-#      end
-
     end
   end
 end

--- a/lib/kitchen/driver/xenserver_version.rb
+++ b/lib/kitchen/driver/xenserver_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Xenserver Kitchen driver
-    XENSERVER_VERSION = "0.1.0"
+    XENSERVER_VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
Add :hostname variable to `kitchen verify` ssh authentication errors.
Remove driver-specific verify(state) method.

This resolves `kitchen verify` ssh authentication errors, but requires users to set either a DNS resolvable hostname for their VM, or else to specify the IP address of their VM as the :hostname variable.  This is not a permanent solution and should be addressed when the driver is updated to allow for use of multiple VM deployments in tandem (DHCP / DNS / name generation functionality).
